### PR TITLE
Adds a circular list for Scrum participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Helps you with your daily Scrum Stand-Up by randomizing the order, provide a time-box and more
 
-
 ## Development
 
 Follow the guidelines in the flutter documentation to enable flutter to run Web Applications:
@@ -19,12 +18,13 @@ Flickr is used to fetch an interesting picture as background. For this feature t
 ### Run
 
 Run the Application:
-```
+
+```bash
     flutter run -d chrome
 ```
 
 ### Deploy
 
-```
+```bash
     flutter build web
 ```

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:standup_randomizer/pages/pages.dart';
 import 'package:standup_randomizer/widgets/widgets.dart';
 
+import 'widgets/circular_list.dart';
+
 void main() => runApp(MyApp());
 
 const double _fabDimension = 60.0;
@@ -37,20 +39,13 @@ class _MainPageState extends State<MainPage> {
       ),
       body: Background(
         child: Center(
-          child: Wrap(
-            spacing: 8.0,
-            runSpacing: 8.0,
-            runAlignment: WrapAlignment.spaceAround,
-            children: <Widget>[
-              TeamMember(),
-              TeamMember(),
-              TeamMember(),
-              TeamMember(),
-              TeamMember(),
-              TeamMember(),
-              TeamMember(),
-              TeamMember(),
-            ],
+          child: CircularList(
+            centerWidget: TeamMember(name: 'Scrum master'),
+            children: List.generate(8, (index) {
+              return TeamMember(
+                name: 'Person $index',
+              );
+            }),
           ),
         ),
       ),

--- a/lib/widgets/circular_list.dart
+++ b/lib/widgets/circular_list.dart
@@ -1,0 +1,92 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+
+class CircularList extends StatelessWidget {
+  final List<Widget> children;
+  final Widget centerWidget;
+
+  const CircularList({
+    Key key,
+    @required this.children,
+    this.centerWidget,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final outerCircleDiameter = min(size.width, size.height);
+    final outerRadius = outerCircleDiameter / 2.0;
+    final innerRadius = outerRadius / 2.0;
+    final betweenRadius = outerRadius * 0.65;
+    final double childrenDiameter =
+        2 * pi * betweenRadius / children.length - 30;
+
+    final topItemAngle = 0.0;
+    final origin = Offset(0, -outerCircleDiameter * 0.04);
+
+    return Container(
+      width: outerCircleDiameter,
+      height: outerCircleDiameter,
+      child: Stack(
+        children: <Widget>[
+          Positioned(
+            left: origin.dx,
+            top: origin.dy,
+            child: Container(
+              width: outerRadius * 2,
+              height: outerRadius * 2,
+              child: Transform.rotate(
+                angle: topItemAngle,
+                child: Stack(
+                  children: List.generate(children.length, (index) {
+                    Offset childPoint = _getChildPoint(index, children.length,
+                        betweenRadius, childrenDiameter);
+                    return Positioned(
+                      left: outerRadius + childPoint.dx,
+                      top: outerRadius + childPoint.dy,
+                      child: Transform.rotate(
+                        angle: -topItemAngle,
+                        child: Container(
+                            width: childrenDiameter,
+                            height: childrenDiameter,
+                            alignment: Alignment.center,
+                            child: children[index]),
+                      ),
+                    );
+                  }),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+              left: origin.dx + outerRadius - innerRadius,
+              top: origin.dy + outerRadius - innerRadius,
+              child: Container(
+                width: innerRadius * 2,
+                height: innerRadius * 2,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.transparent,
+                ),
+                child: centerWidget ?? Container(),
+              ))
+        ],
+      ),
+    );
+  }
+
+  Offset _getChildPoint(
+    int index,
+    int length,
+    double betweenRadius,
+    double childrenDiameter,
+  ) {
+    const double startAngle = -pi / 2.0;
+    double indexAngle = 2 * pi * (index / length);
+    double angel = startAngle + indexAngle;
+    double x = cos(angel) * betweenRadius - childrenDiameter / 2;
+    double y = sin(angel) * betweenRadius - childrenDiameter / 2;
+    return Offset(x, y);
+  }
+}

--- a/lib/widgets/team_member.dart
+++ b/lib/widgets/team_member.dart
@@ -3,8 +3,9 @@ import 'package:flutter/material.dart';
 class TeamMember extends StatefulWidget {
   final double width;
   final double height;
+  final String name;
 
-  const TeamMember({Key key, this.width = 200, this.height = 200})
+  const TeamMember({Key key, this.width = 200, this.height = 200, this.name})
       : super(key: key);
 
   @override
@@ -43,7 +44,7 @@ class _TeamMemberState extends State<TeamMember> {
                 child: Column(
                   children: <Widget>[
                     Text(
-                      'John Doe',
+                      widget.name ?? 'John Doe',
                       style: Theme.of(context).textTheme.headline5,
                     ),
                     Image.asset(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A new Flutter project.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: ">=2.5.2 <3.0.0"
@@ -30,13 +30,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
Replaces Wrap-widget with a Circular-list-widget that displays the scrum participants in a circle around a scrum-master-widget or maybe a ForcePushers-logo-widget.

Also fixes lint warnings in README.md

![Screenshot 2020-05-15 at 21 49 28](https://user-images.githubusercontent.com/35557557/82091056-01d44b00-96f7-11ea-8d8e-76caa9d6f0e1.png)
